### PR TITLE
Update category taxonomies initialization based on permissions

### DIFF
--- a/src/views/events/Duplicate.vue
+++ b/src/views/events/Duplicate.vue
@@ -120,6 +120,7 @@ import http from "@/http";
 import Form from "@/classes/Form";
 import DetailsTab from "@/views/events/forms/DetailsTab";
 import TaxonomiesTab from "@/views/events/forms/TaxonomiesTab";
+import Auth from "@/classes/Auth";
 
 export default {
   name: "OrganisationEventEdit",
@@ -206,9 +207,9 @@ export default {
         homepage: false,
         location_id: this.event.location_id,
         image_file_id: null,
-        category_taxonomies: this.event.category_taxonomies.map(
+        category_taxonomies: Auth.isSuperAdmin ? this.event.category_taxonomies.map(
           (taxonomy) => taxonomy.id
-        ),
+        ) : [],
       });
 
       this.loading = false;


### PR DESCRIPTION
### Summary
https://ayup.atlassian.net/jira/software/projects/ACD/boards/8?selectedIssue=ACD-18&sprintStarted=true

Modify logic to initialize `category_taxonomies` based on user role. Super admins retain the full taxonomy list, while others get an empty array. This ensures proper access control and data handling.

### Development checklist
- [x] The code has been linted `npm run lint --fix`

### Release checklist
If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes
If there are any further notes about the PR then write them here.
